### PR TITLE
Correction des caractères accentués dans EFCBooster.sol

### DIFF
--- a/contracts/EFCBooster.sol
+++ b/contracts/EFCBooster.sol
@@ -118,7 +118,7 @@ contract EFCBooster is Ownable {
         
         // Booster légendaire
         boosters["legendary"] = BoosterInfo({
-            name: "Booster Légendaire",
+            name: "Booster Legendaire",
             price: 1000 * 10**18, // 1000 tokens
             cardCount: 5,
             isActive: true


### PR DESCRIPTION
## Description

Cette PR corrige une erreur de syntaxe dans le contrat `EFCBooster.sol` liée à l'utilisation de caractères accentués (Unicode) dans les chaînes de caractères.

## Problème

Le compilateur Solidity génère l'erreur suivante lors de la compilation :

```
ParserError: Invalid character in string. If you are trying to use Unicode characters, use a unicode"..." string literal.
   --> contracts/EFCBooster.sol:121:19:
    |
121 |             name: "Booster Légendaire",
```

## Solution

J'ai remplacé les caractères accentués par leurs équivalents sans accent :
- "Booster Légendaire" → "Booster Legendaire"

Autre option possible aurait été d'utiliser des chaînes de caractères Unicode avec le préfixe `unicode`, mais la solution adoptée est plus simple et maintient la compatibilité avec tous les outils et versions de compilateurs Solidity.

## Impact

Cette modification permet au contrat de se compiler correctement sans changer le comportement du code.

## Tests

- Le contrat compile désormais sans erreur
- Toutes les fonctionnalités restent inchangées