### PR TITLE
Correction de la compatibilité d'EFCCard avec OpenZeppelin 4.9.3

### DIFF
--- a/contracts/EFCCard.sol
+++ b/contracts/EFCCard.sol
@@ -143,19 +143,37 @@ contract EFCCard is ERC721URIStorage, ERC721Enumerable, Ownable {
         return tokenIds;
     }
     
-    // Override nécessaire pour résoudre les conflits entre ERC721URIStorage et ERC721Enumerable
-    function _update(address to, uint256 tokenId, address auth) internal virtual override(ERC721, ERC721Enumerable) returns (address) {
-        return super._update(to, tokenId, auth);
+    // Override nécessaires pour résoudre les conflits entre ERC721URIStorage et ERC721Enumerable
+    
+    /**
+     * @dev Hook qui est appelé avant tout transfert de tokens
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual override(ERC721, ERC721Enumerable) {
+        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
+    }
+
+    /**
+     * @dev Brûle un token spécifique
+     */
+    function _burn(uint256 tokenId) internal virtual override(ERC721, ERC721URIStorage) {
+        super._burn(tokenId);
     }
     
-    function _increaseBalance(address account, uint128 amount) internal virtual override(ERC721, ERC721Enumerable) {
-        super._increaseBalance(account, amount);
-    }
-    
+    /**
+     * @dev Retourne l'URI d'un token
+     */
     function tokenURI(uint256 tokenId) public view virtual override(ERC721, ERC721URIStorage) returns (string memory) {
         return super.tokenURI(tokenId);
     }
     
+    /**
+     * @dev Vérifie si le contrat implémente une interface
+     */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC721Enumerable, ERC721URIStorage) returns (bool) {
         return super.supportsInterface(interfaceId);
     }


### PR DESCRIPTION
## Description

Cette PR corrige un problème de compatibilité entre notre contrat `EFCCard.sol` et la version d'OpenZeppelin (4.9.3) que nous utilisons. Le contrat ne pouvait pas être compilé en raison d'erreurs liées aux méthodes `_update` et `_increaseBalance` qui ne sont pas correctement implémentées pour cette version.

## Problème

Lors de la compilation, l'erreur suivante apparaît :

```
TypeError: Member "_update" not found or not visible after argument-dependent lookup in type(contract super EFCCard).
   --> contracts/EFCCard.sol:148:16:
    |
148 |         return super._update(to, tokenId, auth);
    |                ^^^^^^^^^^^^^
```

## Solution

J'ai remplacé les méthodes problématiques par les overrides corrects pour OpenZeppelin 4.9.3 :

1. Remplacé `_update` et `_increaseBalance` par `_beforeTokenTransfer` qui est la méthode correcte dans cette version pour gérer la compatibilité entre `ERC721Enumerable` et `ERC721`.

2. Ajouté l'override correct pour `_burn` qui est nécessaire pour la compatibilité avec `ERC721URIStorage`.

Ces changements permettent de maintenir toutes les fonctionnalités existantes tout en assurant la compatibilité avec la version d'OpenZeppelin que nous utilisons.

## Impact

- Le contrat peut maintenant être compilé sans erreur
- Toutes les fonctionnalités restent inchangées
- La compatibilité avec OpenZeppelin 4.9.3 est assurée

## Tests

- Le contrat compile correctement
- Toutes les fonctionnalités ont été testées et fonctionnent comme prévu