### PR TITLE
Correction des constructeurs Ownable dans les contrats

### DIFF
--- a/contracts/EFCBooster.sol
+++ b/contracts/EFCBooster.sol
@@ -64,10 +64,13 @@ contract EFCBooster is Ownable {
      * @param _cardContract Adresse du contrat de cartes NFT
      * @param _baseURI URI de base pour les métadonnées des cartes
      */
-    constructor(address _tokenContract, address _cardContract, string memory _baseURI) Ownable(msg.sender) {
+    constructor(address _tokenContract, address _cardContract, string memory _baseURI) {
         tokenContract = EFCToken(_tokenContract);
         cardContract = EFCCard(_cardContract);
         baseURI = _baseURI;
+        
+        // Définit le propriétaire du contrat
+        _transferOwnership(msg.sender);
         
         // Initialisation des types de boosters
         _initializeBoosterTypes();

--- a/contracts/EFCCard.sol
+++ b/contracts/EFCCard.sol
@@ -40,9 +40,12 @@ contract EFCCard is ERC721URIStorage, ERC721Enumerable, Ownable {
     /**
      * @dev Constructeur
      */
-    constructor() ERC721("EpicFactionCommunity Card", "EFCC") Ownable(msg.sender) {
+    constructor() ERC721("EpicFactionCommunity Card", "EFCC") {
         // Commencer les IDs à 1 au lieu de 0
         _tokenIdCounter.increment();
+        
+        // Définit le propriétaire du contrat
+        _transferOwnership(msg.sender);
     }
     
     /**

--- a/contracts/EFCToken.sol
+++ b/contracts/EFCToken.sol
@@ -19,8 +19,11 @@ contract EFCToken is ERC20, Ownable {
      * @dev Constructeur qui donne tous les tokens créés au créateur du contrat
      * @param initialSupply La quantité initiale de tokens à créer
      */
-    constructor(uint256 initialSupply) ERC20("Epic Faction Community Token", "EFC") Ownable(msg.sender) {
+    constructor(uint256 initialSupply) ERC20("Epic Faction Community Token", "EFC") {
         _mint(msg.sender, initialSupply * 10 ** decimals());
+        
+        // Définit le propriétaire du contrat
+        _transferOwnership(msg.sender);
     }
     
     /**


### PR DESCRIPTION
## Description

Cette PR corrige les erreurs de compilation liées à l'initialisation du modificateur `Ownable` dans les contrats. OpenZeppelin 4.9.3 ne prend pas en charge le passage d'un argument au constructeur `Ownable`.

## Problème

Le compilateur générait l'erreur suivante :

```
TypeError: Wrong argument count for modifier invocation: 1 arguments given but expected 0.
  --> contracts/EFCBooster.sol:67:88:
   |
67 |     constructor(address _tokenContract, address _cardContract, string memory _baseURI) Ownable(msg.sender) {
   |                                                                                        ^^^^^^^^^^^^^^^^^^^
```

Cette erreur se produisait dans les trois contrats principaux :
- `EFCBooster.sol`
- `EFCToken.sol`
- `EFCCard.sol`

## Solution

J'ai corrigé les constructeurs des trois contrats en :

1. Supprimant l'argument `msg.sender` passé au constructeur `Ownable`
2. Ajoutant un appel à `_transferOwnership(msg.sender)` dans le corps du constructeur

Exemple de modification :
```solidity
// Avant
constructor(uint256 initialSupply) ERC20("Epic Faction Community Token", "EFC") Ownable(msg.sender) {
    _mint(msg.sender, initialSupply * 10 ** decimals());
}

// Après
constructor(uint256 initialSupply) ERC20("Epic Faction Community Token", "EFC") {
    _mint(msg.sender, initialSupply * 10 ** decimals());
    // Définit le propriétaire du contrat
    _transferOwnership(msg.sender);
}
```

Cette approche est compatible avec OpenZeppelin 4.9.3 et conserve le comportement d'origine en définissant correctement le propriétaire du contrat.

## Impact

- Les contrats peuvent maintenant être compilés sans erreur
- La fonctionnalité Ownable est préservée avec le même comportement
- Aucun changement de logique métier n'a été effectué

## Tests

- Les contrats ont été compilés avec succès
- Le comportement Ownable fonctionne comme prévu (le déployeur du contrat est défini comme propriétaire)