### PR TITLE
Correction de supportsInterface dans EFCCard.sol

### DIFF
--- a/contracts/EFCCard.sol
+++ b/contracts/EFCCard.sol
@@ -177,7 +177,7 @@ contract EFCCard is ERC721URIStorage, ERC721Enumerable, Ownable {
     /**
      * @dev Vérifie si le contrat implémente une interface
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC721Enumerable, ERC721URIStorage) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Enumerable, ERC721URIStorage) returns (bool) {
         return super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## Description

Cette PR corrige une erreur de compilation concernant la méthode `supportsInterface` dans le contrat `EFCCard.sol`. L'erreur était due à un conflit d'héritage dans la déclaration `override` de cette fonction.

## Problème

Le compilateur générait l'erreur suivante :

```
TypeError: Invalid contract specified in override list: "ERC721".
   --> contracts/EFCCard.sol:180:72:
    |
180 |     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC721Enumerable, ERC721URIStorage) returns (bool) {
    |                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: This contract:
  --> @openzeppelin/contracts/token/ERC721/ERC721.sol:19:1:
   |
19 | contract ERC721 is Context, ERC165, IERC721, IERC721Metadata {
   | ^ (Relevant source part starts here and spans across multiple lines).
```

Le problème est que dans OpenZeppelin 4.9.3, la chaîne d'héritage et la façon dont les overrides doivent être spécifiés a changé.

## Solution

J'ai modifié la déclaration de la fonction `supportsInterface` pour n'inclure que les classes directement héritées qui ont cette fonction :

```solidity
// Avant
function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, ERC721Enumerable, ERC721URIStorage) returns (bool) {
    return super.supportsInterface(interfaceId);
}

// Après
function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721Enumerable, ERC721URIStorage) returns (bool) {
    return super.supportsInterface(interfaceId);
}
```

Cette modification respecte correctement la hiérarchie d'héritage dans OpenZeppelin 4.9.3, où `ERC721Enumerable` et `ERC721URIStorage` héritent déjà de `ERC721`, donc il n'est pas nécessaire de l'inclure explicitement dans la liste des overrides.

## Impact

- Le contrat peut maintenant être compilé sans erreur
- La fonctionnalité reste identique car le comportement de la fonction `supportsInterface` n'a pas changé
- Cette correction est conforme aux meilleures pratiques d'OpenZeppelin 4.9.3